### PR TITLE
Add configuration file to list multiple songs directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ For now, you have to have the golang binary installed. For that, check out, chec
 
 **NOTE:** This was made in a Linux environment, with a Music directory. There are plans to add directories via json/yaml file later, but for now you **need** to have the `$HOME/Music` directory. 
 
+## Configuration
+You can specify a list of song directories by creating a JSON file at `$HOME/.config/teamus.json` or `$HOME/.teamus.json`.
+File example:
+```json
+{
+  "directories": [
+    "/home/user/Music",
+    "/home/user/My_Musics"
+  ]
+}
+```
+
 ## TODOs
 
 - [ ] Seamless playing, with shuffle
 - [ ] Repeat Music / Playlist
-- [ ] Choose files from multiple directories, specified in json.
+- [X] Choose files from multiple directories, specified in json.
 - [ ] Load from direectory, refresh only on keypress.
 
 ### Additional Features

--- a/config.go
+++ b/config.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path"
+)
+
+type Config struct {
+	Directories []string `json:"directories"`
+}
+
+func LoadConfig() *Config {
+	content := findConfigFile()
+	if content == nil {
+		return defaultConfig()
+	}
+
+	conf := new(Config)
+	err := json.Unmarshal(content, conf)
+	if err != nil {
+		return defaultConfig()
+	}
+
+	return conf
+}
+
+func findConfigFile() []byte {
+	// searches in $HOME/.config
+	configPath := path.Join(mustUserHomeDir(), ".config", "teamus.json")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			log.Fatal("Failed to read Config file" + err.Error())
+		}
+		return content
+	}
+
+	// searches in $HOME for config file
+	configPath = path.Join(mustUserHomeDir(), ".teamus.json")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			log.Fatal("Failed to read Config file" + err.Error())
+		}
+		return content
+	}
+
+	return nil
+}
+
+func defaultConfig() *Config {
+	home := mustUserHomeDir()
+	dirs := []string{
+		path.Join(home, "Music"),
+	}
+	return &Config{
+		Directories: dirs,
+	}
+}
+
+func mustUserHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal("Cannot find Home Directory" + err.Error())
+	}
+
+	return home
+}

--- a/main.go
+++ b/main.go
@@ -321,18 +321,9 @@ func listPaths(roots []string) {
 }
 
 func main() {
-	// TODO: Store it in a database. Searching for files everytime is just plain
-	// retarded. Also add ability to add more paths via json.
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal("Cannot find Home Directory" + err.Error())
-	}
-	musdir := filepath.Join(home, "Music")
-	if _, err := os.Stat(musdir); err != nil {
-		log.Fatal("Could not find or open Music Directory" + err.Error())
-	}
+	config := LoadConfig()
 
-	listPaths([]string{musdir})
+	listPaths(config.Directories)
 	var trackList []list.Item
 
 	noOfFiles := len(fileList)


### PR DESCRIPTION
Hey, I just added the configuration file for this project.
I didn't found more information about how you would like to implement it, so I made this way.

The config can be made at `$HOME/.config/teamus.json` or at `$HOME/.teamus.json` (as I added in README.md) using the following example:
```json
{
  "directories": [
    "/home/user/Music",
    "/home/user/My_Musics"
  ]
}
```

This was only tested on Windows, so maybe it need some changes to run on Linux. 

I'm open to make any changes in the configuration structure, like accept other file's type like yaml. Or even the configuration location.

By the way, nice project! Worked great in Windows.